### PR TITLE
Create base template

### DIFF
--- a/src/Presentation/Controllers/CategoryController.php
+++ b/src/Presentation/Controllers/CategoryController.php
@@ -1,15 +1,27 @@
 <?php
     declare(strict_types=1);
+
     namespace Lenovo\ProyectoRefactorizacion\Presentation\Controllers;
+
+    use Lenovo\ProyectoRefactorizacion\Presentation\Views\ViewRenderer;
     
     class CategoryController
     {
+        private ViewRenderer $_viewRenderer;
+
+        public function __construct(){
+            $viewsPath = __DIR__ . '/../../../views';
+            $this->_viewRenderer = new ViewRenderer($viewsPath);
+        }
+
         public function index() {
-            echo "Mostrando todas las categorías";
+            $this->_viewRenderer->render('category/index', [
+            'titulo' => 'Foro Principal'
+        ]);
         }
 
         public function show(string $id): void {
-            echo "Mostrando detalles de la categoría con ID: " . $id;
+            echo "Mostrando el contenido de la categoría con ID: " . htmlspecialchars($id);
         }
     }
 ?>

--- a/src/Presentation/Views/ViewRenderer.php
+++ b/src/Presentation/Views/ViewRenderer.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lenovo\ProyectoRefactorizacion\Presentation\Views;
+
+use RuntimeException;
+
+class ViewRenderer
+{
+    private string $_viewsPath;
+    private string $_layoutName;
+
+    public function __construct(string $viewsPath, string $layoutName = 'main')
+    {
+        $this->_viewsPath = rtrim($viewsPath, '/');
+        $this->_layoutName = $layoutName;
+    }
+
+    public function render(string $viewName, array $data = []): void
+    {
+        $viewFile = $this->_viewsPath . '/' . $viewName . '.php';
+        $layoutFile = $this->_viewsPath . '/layouts/' . $this->_layoutName . '.php';
+
+        if (!file_exists($viewFile)) {
+            throw new RuntimeException("La vista '{$viewFile}' no existe.");
+        }
+
+        if (!file_exists($layoutFile)) {
+            throw new RuntimeException("El layout '{$layoutFile}' no existe.");
+        }
+
+        extract($data);
+
+        ob_start();
+        require $viewFile;
+        $content = ob_get_clean();
+
+        require $layoutFile;
+    }
+}

--- a/views/category/index.php
+++ b/views/category/index.php
@@ -1,0 +1,8 @@
+<?php declare(strict_types=1); ?>
+
+<h1>Bienvenido a los foros de iDiscuss</h1>
+<p>Explora las categorías a continuación:</p>
+
+<div class="categories-list">
+    <p>Categoría 1: Python (Muestra de contenido dinámico)</p>
+</div>

--- a/views/layouts/main.php
+++ b/views/layouts/main.php
@@ -1,0 +1,29 @@
+<?php declare(strict_types=1); ?>
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>iDiscuss Foro - Refactorizado</title>
+    </head>
+<body>
+
+    <header>
+        <nav>
+            <ul>
+                <li><a href="/proyectorefactorizacion/public/">Inicio</a></li>
+                <li><a href="/proyectorefactorizacion/public/about">Acerca de</a></li>
+            </ul>
+        </nav>
+    </header>
+
+    <main>
+        <?php echo $content; ?>
+    </main>
+
+    <footer>
+        <p>&copy; <?php echo date('Y'); ?> iDiscuss. Todos los derechos reservados.</p>
+    </footer>
+
+</body>
+</html>


### PR DESCRIPTION
## 📝 ¿Qué hace este cambio?
Este PR implementa un sistema de renderizado de vistas modular, extrayendo el HTML repetido (header, nav, footer) en un Layout maestro, solucionando el problema de repetición de código del iDiscuss original.

Se lograron los siguientes avances:
1. **Layout Maestro:** Se creó `views/layouts/main.php` para centralizar la estructura de la página.
2. **Motor de Vistas:** Se implementó la clase `ViewRenderer` encargada de inyectar el contenido específico de cada página dentro del layout base mediante búferes de salida (`ob_start`).
3. **Vistas Limpias:** El archivo `views/category/index.php` ahora es 100% puro y solo contiene el fragmento HTML que le corresponde.

## 🏗️ Principios y Buenas Prácticas Aplicadas

- **SRP (Responsabilidad Única):**  
  Los controladores ya no se preocupan por "cómo" cargar un HTML. Esa responsabilidad se delegó completamente a la clase `ViewRenderer`.

- **DRY (Don't Repeat Yourself):**  
  Se eliminó la duplicación del menú de navegación y el footer en cada página.

- **OCP, LSP, ISP, DIP:**  
  No aplican directamente en este PR, ya que no se están definiendo extensiones, contratos o jerarquías que lo requieran.

- **Clean Code:**  
  Se respetó la nomenclatura `$_viewsPath` y `$_layoutName` para propiedades privadas.  
  El HTML está completamente separado de la lógica de negocio.

## 🔗 Issue relacionado
Closes #4 