### PR TITLE
Implement category use case

### DIFF
--- a/src/Application/UseCases/GetCategoriesUseCase.php
+++ b/src/Application/UseCases/GetCategoriesUseCase.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lenovo\ProyectoRefactorizacion\Application\UseCases;
+
+class GetCategoriesUseCase
+{
+    private CategoryRepositoryInterface $_categoryRepository;
+
+    public function __construct(CategoryRepositoryInterface $categoryRepository)
+    {
+        $this->_categoryRepository = $categoryRepository;
+    }
+
+    /**
+     * Ejecuta el caso de uso para obtener todas las categorías.
+     *
+     * @return array<\Lenovo\ProyectoRefactorizacion\Domain\Entities\Category>
+     */
+    
+    public function execute(): array
+    {
+        return $this->_categoryRepository->getAll();
+    }
+
+}


### PR DESCRIPTION
## 📝 ¿Qué hace este cambio?
Este PR implementa el primer Caso de Uso de la aplicación (`GetCategoriesUseCase`), el cual actúa como el orquestador principal para la funcionalidad de listar las categorías del foro.

Se lograron los siguientes avances:
1. **Orquestación:** Se creó la clase `GetCategoriesUseCase` dentro de la capa de Aplicación.
2. **Inyección de Dependencias:** El caso de uso recibe la interfaz del repositorio por constructor, garantizando que la lógica de la aplicación esté completamente desacoplada de la infraestructura (MySQL/PDO).

## 🏗️ Principios y Buenas Prácticas Aplicadas

- [x] **SRP (Responsabilidad Única):** La clase tiene un único propósito: ejecutar el flujo necesario para obtener las categorías. Si en el futuro necesitamos aplicar un filtro o una regla de negocio antes de devolver los datos, se hará aquí sin tocar los controladores.
- [x] **DIP (Inversión de Dependencias):** El caso de uso depende de la abstracción `CategoryRepositoryInterface` (Capa de Dominio) y no de la implementación concreta de la base de datos (Capa de Infraestructura).
- [x] **Clean Code:** Se mantuvo la nomenclatura acordada (`$_categoryRepository` para propiedades privadas) y se documentó el retorno de la función `execute()` especificando que devuelve un array de entidades `Category`.

## 🔗 Issue relacionado
Closes #6 