### PR TITLE
EntidadThreadeInterfaz

### DIFF
--- a/src/Domain/Entities/Thread.php
+++ b/src/Domain/Entities/Thread.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lenovo\ProyectoRefactorizacion\Domain\Entities;
+
+class Thread
+{
+    private int $_id;
+    private string $_title;
+    private string $_description;
+    private int $_categoryId;
+    private int $_userId;
+    private string $_timestamp;
+
+    public function __construct(
+        int $id, 
+        string $title, 
+        string $description, 
+        int $categoryId, 
+        int $userId, 
+        string $timestamp
+    ) {
+        $this->_id = $id;
+        $this->_title = $title;
+        $this->_description = $description;
+        $this->_categoryId = $categoryId;
+        $this->_userId = $userId;
+        $this->_timestamp = $timestamp;
+    }
+
+    public function getId(): int
+    {
+        return $this->_id;
+    }
+
+    public function getTitle(): string
+    {
+        return $this->_title;
+    }
+
+    public function getDescription(): string
+    {
+        return $this->_description;
+    }
+
+    public function getCategoryId(): int
+    {
+        return $this->_categoryId;
+    }
+
+    public function getUserId(): int
+    {
+        return $this->_userId;
+    }
+
+    public function getTimestamp(): string
+    {
+        return $this->_timestamp;
+    }
+}

--- a/src/Domain/Repositories/ThreadRepositoryInterface.php
+++ b/src/Domain/Repositories/ThreadRepositoryInterface.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lenovo\ProyectoRefactorizacion\Domain\Repositories;
+
+interface ThreadRepositoryInterface
+{
+    /**
+     * Obtiene todos los hilos que pertenecen a una categoría específica.
+     *
+     * @param int $categoryId El ID de la categoría
+     * @return array<\Lenovo\ProyectoRefactorizacion\Domain\Entities\Thread>
+     */
+    public function getByCategoryId(int $categoryId): array;
+}


### PR DESCRIPTION
## 📝 ¿Qué hace este cambio?
Este PR expande la Capa de Dominio introduciendo el núcleo de negocio para los temas/hilos del foro.

Se lograron los siguientes avances:
1. **Entidad `Thread`:** Se modeló la clase base reflejando las columnas de la tabla `threads` (`id`, `title`, `description`, `categoryId`, `userId`, `timestamp`) usando propiedades privadas y getters.
2. **Contrato de Repositorio:** Se creó la interfaz `ThreadRepositoryInterface` que define el método `getByCategoryId()` para recuperar los hilos asociados a una categoría específica.

## 🏗️ Principios y Buenas Prácticas Aplicadas

- [x] **SRP (Responsabilidad Única):** La entidad `Thread` tiene la única responsabilidad de representar la estructura de datos del hilo en memoria. No sabe cómo guardarse ni cómo mostrarse.
- [x] **DIP (Inversión de Dependencias):** Se definió el contrato (`ThreadRepositoryInterface`) que la capa de Aplicación usará más adelante, asegurando que las reglas de negocio no dependan de MySQL.
- [x] **Clean Code:** Se implementó tipado estricto (`declare(strict_types=1);`). Se utilizó la nomenclatura acordada (`$_nombreVariable`) para encapsular las propiedades privadas y proteger el estado del objeto.

## 🔗 Issue relacionado
Closes #20