### PR TITLE
Se implemento MySQLThreadRepository

### DIFF
--- a/src/Infrastructure/Persistence/MySQLThreadRepository.php
+++ b/src/Infrastructure/Persistence/MySQLThreadRepository.php
@@ -28,7 +28,7 @@ class MySQLThreadRepository implements ThreadRepositoryInterface
     public function getByCategoryId(int $categoryId): array
     {
         try {
-            // Usamos el nombre real de las columnas según tu base de datos
+            // Se consultan las columnas persistidas en la tabla threads
             $query = "SELECT threads_id, threads_title, threads_desc, threads_cat_id, threads_user_id, threads_reg_date
                       FROM threads 
                       WHERE threads_cat_id = :categoryId";


### PR DESCRIPTION
## 📝 ¿Qué hace este cambio?
Este PR implementa el repositorio concreto para los hilos, conectando la capa de Infraestructura con la base de datos real.

Se lograron los siguientes avances:
1. **Consultas Seguras:** Se implementó `MySQLThreadRepository` usando sentencias preparadas de PDO (`bindParam`) para filtrar los hilos por categoría, previniendo inyecciones SQL.
2. **Mapeo de Datos:** Se transformaron los resultados crudos de la tabla `threads` en objetos puros de la entidad `Thread`.

## 🏗️ Principios y Buenas Prácticas Aplicadas
- [x] **SRP (Responsabilidad Única):** La clase solo gestiona la persistencia y lectura de los hilos.
- [x] **DIP (Inversión de Dependencias):** Se recibe la conexión `PDO` por constructor.
- [x] **Clean Code:** Se mantuvo la nomenclatura `$_connection`, se manejaron excepciones limpiamente y se documentó el retorno del método.

## 🔗 Issue relacionado
Closes #21