### PR TITLE
Se agrega GetThreadsByCategoryUseCase para obtener hilos por categoría 

### DIFF
--- a/src/Application/UseCases/GetThreadsByCategoryUseCase.php
+++ b/src/Application/UseCases/GetThreadsByCategoryUseCase.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lenovo\ProyectoRefactorizacion\Application\UseCases;
+use Lenovo\ProyectoRefactorizacion\Domain\Repositories\ThreadRepositoryInterface;
+
+ class GetThreadsByCategoryUseCase{
+
+    private readonly ThreadRepositoryInterface $_threadRepository;
+
+    public function __construct(ThreadRepositoryInterface $threadRepository)
+    {
+        $this->_threadRepository = $threadRepository;
+    }
+
+    /**
+     * Ejecuta el caso de uso para obtener los hilos por categoría.
+     *
+     * @param int $categoryId El ID de la categoría.
+     * @return array<\Lenovo\ProyectoRefactorizacion\Domain\Entities\Thread> El array de hilos correspondientes a la categoría.
+     */
+    public function execute(int $categoryId): array
+    {
+        return $this->_threadRepository->getByCategoryId($categoryId);
+    }
+ }
+
+


### PR DESCRIPTION
📄 ¿Qué hace este cambio?

Se agrega `GetThreadsByCategoryUseCase` que actúa como orquestador 
para obtener los hilos correspondientes a una categoría.

Se lograron los siguientes avances:

1. **Caso de Uso**: Se creó `GetThreadsByCategoryUseCase` que recibe 
   `ThreadRepositoryInterface` por constructor.
2. **Método execute**: Recibe un `int $categoryId` y delega la consulta 
   al repositorio, retornando el array de hilos correspondientes.
3. **Aislamiento de lógica**: La lógica de aplicación queda separada 
   de la infraestructura.

## Principios y Buenas Prácticas Aplicadas

- ✅ **DIP (Inversión de Dependencias)**: El caso de uso depende de la 
  interfaz `ThreadRepositoryInterface`, no de una implementación concreta.
- ✅ **SRP (Responsabilidad Única)**: La clase solo tiene la responsabilidad 
  de orquestar la obtención de hilos por categoría.
- ✅ **Clean Architecture**: El caso de uso se ubica en la capa `Application`, 
  dependiendo únicamente hacia el Dominio.

## 🔗 Issue relacionado

Closes #22