### PR TITLE
Se agrego vista thread/list.php con sintaxis alternativa de PHP

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -30,8 +30,8 @@ $pdo = $databaseConnection->connect();
 $categoryRepository = new MySQLCategoryRepository($pdo);
 $getCategoriesUseCase = new GetCategoriesUseCase($categoryRepository);
 
-$categoryRepository = new MySQLCategoryRepository($pdo);
-$getThreadsByCategoryUseCase = new GetThreadsByCategoryUseCase($categoryRepository);
+$threadRepository = new MySQLThreadRepository($pdo);
+$getThreadsByCategoryUseCase = new GetThreadsByCategoryUseCase($threadRepository);
 
 $viewsPath = __DIR__ . '/../views';
 $viewRenderer = new ViewRenderer($viewsPath);

--- a/views/thread/list.php
+++ b/views/thread/list.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * @param array<\Lenovo\ProyectoRefactorizacion\Domain\Entities\Thread> $threads
+ */
+?>
+<div class="container mt-4">
+    <h2>Lista de Temas</h2>
+    <div class="list-group">
+        <?php foreach ($threads as $thread): ?>
+            <a href="#" class="list-group-item list-group-item-action">
+                <h5 class="mb-1"><?php echo htmlspecialchars($thread->getTitle()); ?></h5>
+                <p class="mb-1"><?php echo htmlspecialchars($thread->getContent()); ?></p>
+                <small>Publicado el <?php echo $thread->getCreatedAt()->format('d/m/Y'); ?></small>
+            </a>
+        <?php endforeach; ?>
+    </div>
+</div>


### PR DESCRIPTION
## 📄 ¿Qué hace este cambio?

Se crea el archivo `views/thread/list.php` para mostrar la lista 
de hilos correspondientes a una categoría.

Se lograron los siguientes avances:

1. **Vista de hilos**: Recibe `$threads` del controlador y renderiza 
   la lista usando Bootstrap.
2. **Sintaxis alternativa**: Se usa `foreach (...): ... endforeach;` 
   como buena práctica en vistas PHP.
3. **Seguridad**: Se aplica `htmlspecialchars()` en todos los datos 
   para evitar XSS.

## 🏗️ Principios y Buenas Prácticas Aplicadas

- ✅ **Sin lógica de negocio**: Cero consultas SQL ni procesamiento de datos.
- ✅ **Separación de responsabilidades**: La vista solo se encarga de presentar.
- ✅ **Clean Code**: Uso de `htmlspecialchars()` y formato de fecha legible.

## 🔗 Issue relacionado

Closes #24 