### PR TITLE
Create ThreadController and Routing

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -12,6 +12,7 @@ use Lenovo\ProyectoRefactorizacion\Application\UseCases\GetThreadsByCategoryUseC
 use Lenovo\ProyectoRefactorizacion\Presentation\Views\ViewRenderer;
 use Lenovo\ProyectoRefactorizacion\Presentation\Controllers\CategoryController;
 use Lenovo\ProyectoRefactorizacion\Presentation\Routing\RouterConfigurator;
+use Lenovo\ProyectoRefactorizacion\Presentation\Controllers\ThreadController;
 
 use Dotenv\Dotenv;
 
@@ -42,7 +43,12 @@ $categoryController = new CategoryController(
     $viewRenderer
 );
 
+$threadController = new ThreadController(
+    $getCommentsByThreadUseCase,
+    $viewRenderer
+);
+
 $router = new Router();
-$routerConfigurator = new RouterConfigurator($router, $categoryController);
+$routerConfigurator = new RouterConfigurator($router, $categoryController, $threadController);
 $routerConfigurator->registerRoutes();
 $router->run();

--- a/src/Presentation/Controllers/ThreadController.php
+++ b/src/Presentation/Controllers/ThreadController.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lenovo\ProyectoRefactorizacion\Presentation\Controllers;
+
+use Lenovo\ProyectoRefactorizacion\Application\UseCases\GetCommentsByThreadUseCase;
+use Lenovo\ProyectoRefactorizacion\Presentation\Views\ViewRenderer;
+
+class ThreadController
+{
+    private GetCommentsByThreadUseCase $_getCommentsByThreadUseCase;
+    private ViewRenderer $_viewRenderer;
+
+    public function __construct(
+        GetCommentsByThreadUseCase $getCommentsByThreadUseCase,
+        ViewRenderer $viewRenderer
+    ) {
+        $this->_getCommentsByThreadUseCase = $getCommentsByThreadUseCase;
+        $this->_viewRenderer = $viewRenderer;
+    }
+
+    public function show(string $id): void
+    {
+        $threadId = (int) $id;
+        $comments = $this->_getCommentsByThreadUseCase->execute($threadId);
+
+        $this->_viewRenderer->render('thread/show', [
+            'comments' => $comments,
+            'threadId' => $threadId
+        ]);
+    }
+}

--- a/src/Presentation/Routing/RouterConfigurator.php
+++ b/src/Presentation/Routing/RouterConfigurator.php
@@ -6,16 +6,23 @@
 
     use Bramus\Router\Router;
     use Lenovo\ProyectoRefactorizacion\Presentation\Controllers\CategoryController;
+    use Lenovo\ProyectoRefactorizacion\Presentation\Controllers\ThreadController;
 
     class RouterConfigurator
     {
         private Router $_router;
         private CategoryController $_categoryController;
+        private ThreadController $_threadController;
 
-        public function __construct(Router $router, CategoryController $categoryController)
-        {
+        public function __construct(
+            Router $router, 
+            CategoryController $categoryController,
+            ThreadController $threadController
+        ){
             $this->_router = $router;
             $this->_categoryController = $categoryController;
+            $this->_threadController = $threadController;
+            
         }
 
         public function registerRoutes(): void
@@ -23,14 +30,19 @@
             $basePath = str_replace('/index.php', '', $_SERVER['SCRIPT_NAME']);
             $this->_router->setBasePath($basePath);
 
-            $controller = $this->_categoryController;
+            $categoryController = $this->_categoryController;
+            $threadController = $this->_threadController;
 
-            $this->_router->get('/', function () use ($controller) {
-                $controller->index();
+            $this->_router->get('/', function () use ($categoryController) {
+                $categoryController->index();
             });
 
-            $this->_router->get('/categoria/(\d+)', function (string $id) use ($controller) {
-                $controller->show($id);
+            $this->_router->get('/categoria/(\d+)', function (string $id) use ($categoryController) {
+                $categoryController->show($id);
+            });
+
+            $this->_router->get('/hilo/(\d+)', function (string $id) use ($threadController) {
+                $threadController->show($id);
             });
         }
     }


### PR DESCRIPTION
## 📝 ¿Qué hace este cambio?
Este PR se encarga de crear el controlador específico para los hilos del foro y establecer la ruta pública (`/hilo/{id}`) que permitirá a los usuarios acceder a una pregunta y ver todos sus comentarios asociados.

Se lograron los siguientes avances:
1. **Controlador Especializado:** Se creó `ThreadController` con el método `show()` que orquesta la carga de comentarios.
2. **Registro de Ruta:** Se actualizó `RouterConfigurator` para escuchar las peticiones GET en `/hilo/(\d+)` delegando la ejecución a través de Closures.
3. **Ensamblaje (Wiring):** Se instanció el nuevo repositorio de comentarios, el caso de uso y el controlador en `public/index.php`, manteniendo todo unificado.

## 🏗️ Principios y Buenas Prácticas Aplicadas

- [x] **SRP (Responsabilidad Única):** La visualización de un hilo individual y sus comentarios ahora tiene su propio controlador, evitando que `CategoryController` crezca desproporcionadamente (fat controller).
- [x] **DIP (Inversión de Dependencias):** Siguiendo la arquitectura del proyecto, `ThreadController` no asume cómo conseguir los comentarios ni instanciar la vista; exige que `GetCommentsByThreadUseCase` y `ViewRenderer` se le inyecten por constructor.
- [x] **Clean Code:** Uso estricto de nomenclatura interna (`$_threadController`), casteo seguro a enteros (`(int) $id`) antes de mandar el ID a la capa de aplicación.

## 🔗 Issue relacionado
Closes #33