### PR TITLE
Feature/create thread usecase

### DIFF
--- a/src/Application/UseCases/CreateThreadUseCase.php
+++ b/src/Application/UseCases/CreateThreadUseCase.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lenovo\ProyectoRefactorizacion\Application\UseCases;
+
+use Lenovo\ProyectoRefactorizacion\Domain\Entities\Thread;
+use Lenovo\ProyectoRefactorizacion\Domain\Repositories\ThreadRepositoryInterface;
+
+class CreateThreadUseCase
+{
+    private readonly ThreadRepositoryInterface $_threadRepository;
+
+    public function __construct(ThreadRepositoryInterface $threadRepository)
+    {
+        $this->_threadRepository = $threadRepository;
+    }
+
+    public function execute(string $title, string $description, int $categoryId, int $userId): void
+    {
+        $thread = new Thread(
+            0,
+            $title,
+            $description,
+            $categoryId,
+            $userId,
+            date('Y-m-d H:i:s')
+        );
+
+        $this->_threadRepository->save($thread);
+    }
+}


### PR DESCRIPTION
Este PR implementa el caso de uso CreateThreadUseCase dentro de la capa de aplicación, permitiendo la creación de nuevos hilos en el sistema.

## Específicamente se logró lo siguiente:

1. Se creó la clase CreateThreadUseCase.
2. Se aplicó inyección de dependencias mediante ThreadRepositoryInterface.
3. Se implementó el método execute(...) para instanciar la entidad Thread con los datos recibidos.
4. Se delega la persistencia del hilo al repositorio mediante el método save().

## Principios y Buenas Prácticas Aplicadas

- SRP (Responsabilidad Única): El caso de uso se encarga exclusivamente de la creación de hilos.
- DIP (Inversión de Dependencias): Se depende de ThreadRepositoryInterface en lugar de una implementación concreta.
- Clean Architecture: Se mantiene la separación entre Application, Domain e Infrastructure.

## Issue relacionado

Closes #36