### PR TITLE
Feature/get comments by thread usecase

### DIFF
--- a/src/Application/UseCases/GetCommentsByThreadUseCase.php
+++ b/src/Application/UseCases/GetCommentsByThreadUseCase.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lenovo\ProyectoRefactorizacion\Application\UseCases;
+
+use Lenovo\ProyectoRefactorizacion\Domain\Repositories\CommentRepositoryInterface;
+
+class GetCommentsByThreadUseCase
+{
+    private readonly CommentRepositoryInterface $_commentRepository;
+
+    public function __construct(CommentRepositoryInterface $commentRepository)
+    {
+        $this->_commentRepository = $commentRepository;
+    }
+
+    /**
+     * Obtiene todos los comentarios de un hilo específico.
+     *
+     * @param int $threadId
+     * @return array
+     */
+    public function execute(int $threadId): array
+    {
+        return $this->_commentRepository->getByThreadId($threadId);
+    }
+}


### PR DESCRIPTION
Este PR implementa el caso de uso GetCommentsByThreadUseCase dentro de la capa de aplicación, permitiendo obtener los comentarios asociados a un hilo específico.

## Específicamente se logró lo siguiente:

1. Se creó la clase GetCommentsByThreadUseCase.
2. Se aplicó inyección de dependencias mediante CommentRepositoryInterface.
3. Se implementó el método execute(...) para recuperar los comentarios de un hilo.
4. Se delega la consulta al repositorio mediante el método getByThreadId().

## Principios y Buenas Prácticas Aplicadas

- SRP (Responsabilidad Única): El caso de uso se encarga exclusivamente de obtener comentarios por hilo.
- DIP (Inversión de Dependencias): Se depende de una interfaz en lugar de una implementación concreta.
- Clean Architecture: La lógica de aplicación se mantiene desacoplada de la infraestructura.

## Issue relacionado

Closes #32