### PR TITLE
Implementa control de acceso y seguridad en rutas POST (creación de hilos y comentarios)

### DIFF
--- a/src/Domain/Repositories/CommentRepositoryInterface.php
+++ b/src/Domain/Repositories/CommentRepositoryInterface.php
@@ -9,4 +9,11 @@ interface CommentRepositoryInterface {
      * @return array<\Lenovo\ProyectoRefactorizacion\Domain\Entities\Comment>
      */
     public function getByThreadId(int $threadId): array;
+
+    /**
+     * Guarda un comentario en la base de datos.
+     * @param \Lenovo\ProyectoRefactorizacion\Domain\Entities\Comment $comment
+     * @return bool
+     */
+    public function save(\Lenovo\ProyectoRefactorizacion\Domain\Entities\Comment $comment): bool;
 }

--- a/src/Infrastructure/Persistence/MySQLCommentRepository.php
+++ b/src/Infrastructure/Persistence/MySQLCommentRepository.php
@@ -1,3 +1,30 @@
+    /**
+     * Guarda un comentario en la base de datos.
+     * @param Comment $comment
+     * @return bool
+     */
+    public function save(Comment $comment): bool
+    {
+        try {
+            $query = "INSERT INTO comments (comment_content, thread_id, comment_by, comment_date) VALUES (:content, :threadId, :userId, :timestamp)";
+            $statement = $this->_connection->prepare($query);
+            $content = $comment->getContent();
+            $threadId = $comment->getThreadId();
+            $userId = $comment->getUserId();
+            $timestamp = $comment->getTimestamp();
+            $statement->bindParam(':content', $content, PDO::PARAM_STR);
+            $statement->bindParam(':threadId', $threadId, PDO::PARAM_INT);
+            $statement->bindParam(':userId', $userId, PDO::PARAM_INT);
+            $statement->bindParam(':timestamp', $timestamp, PDO::PARAM_STR);
+            return $statement->execute();
+        } catch (PDOException $exception) {
+            throw new RuntimeException(
+                "Error al guardar el comentario en la base de datos.",
+                (int) $exception->getCode(),
+                $exception
+            );
+        }
+    }
 <?php
 
 declare(strict_types=1);
@@ -55,6 +82,34 @@ class MySQLCommentRepository implements CommentRepositoryInterface
         } catch (PDOException $exception) {
             throw new RuntimeException(
                 "Error al obtener los comentarios de la base de datos.",
+                (int) $exception->getCode(),
+                $exception
+            );
+        }
+    }
+
+    /**
+     * Guarda un comentario en la base de datos.
+     * @param Comment $comment
+     * @return bool
+     */
+    public function save(Comment $comment): bool
+    {
+        try {
+            $query = "INSERT INTO comments (comment_content, thread_id, comment_by, comment_date) VALUES (:content, :threadId, :userId, :timestamp)";
+            $statement = $this->_connection->prepare($query);
+            $content = $comment->getContent();
+            $threadId = $comment->getThreadId();
+            $userId = $comment->getUserId();
+            $timestamp = $comment->getTimestamp();
+            $statement->bindParam(':content', $content, PDO::PARAM_STR);
+            $statement->bindParam(':threadId', $threadId, PDO::PARAM_INT);
+            $statement->bindParam(':userId', $userId, PDO::PARAM_INT);
+            $statement->bindParam(':timestamp', $timestamp, PDO::PARAM_STR);
+            return $statement->execute();
+        } catch (PDOException $exception) {
+            throw new RuntimeException(
+                "Error al guardar el comentario en la base de datos.",
                 (int) $exception->getCode(),
                 $exception
             );


### PR DESCRIPTION
📝 ¿Qué hace este cambio?

Este PR implementa la capa de seguridad y control de acceso (Middleware Básico) para las rutas que mutan el estado de la aplicación (POST). Ahora, la creación de hilos y comentarios está estrictamente reservada para usuarios autenticados.

Se lograron los siguientes avances:

Gestión de Sesiones: Se inicializó globalmente session_start() en el Front Controller (index.php) para tener acceso al estado del usuario en toda la app.
Protección de Controladores: Se añadieron guardias (if (!isset($_SESSION['user_id']))) en los métodos storeThread y storeComment que interceptan a los visitantes no autenticados y los redirigen a la pantalla de login.
Integridad de Datos: El user_id necesario para los Casos de Uso de creación ahora se extrae de forma segura desde la variable superglobal $_SESSION del servidor, previniendo que un usuario malicioso falsifique su identidad alterando el HTML.
🏗️ Principios y Buenas Prácticas Aplicadas

Seguridad Informática: Implementación del patrón Post-Redirect-Get (PRG) para evitar el reenvío de formularios por error, y uso de sesiones del lado del servidor para validar la identidad.
Clean Code: Salidas tempranas (Early Returns) utilizando exit; después de los header('Location: ...') para asegurar que el script de PHP se detenga completamente y no ejecute los Casos de Uso de forma fantasma.
🔗 Issue relacionado
Closes #37