### PR TITLE
Agregar método save() al repositorio de hilos (MySQLThreadRepository) y a la interfaz

### DIFF
--- a/src/Domain/Repositories/ThreadRepositoryInterface.php
+++ b/src/Domain/Repositories/ThreadRepositoryInterface.php
@@ -21,5 +21,11 @@ interface ThreadRepositoryInterface
      * @return array<\Lenovo\ProyectoRefactorizacion\Domain\Entities\Thread>
      */
     public function search(string $keyword): array;
-    
+
+    /**
+     * Guarda un hilo en la base de datos.
+     * @param \Lenovo\ProyectoRefactorizacion\Domain\Entities\Thread $thread
+     * @return bool
+     */
+    public function save(\Lenovo\ProyectoRefactorizacion\Domain\Entities\Thread $thread): bool;
 }

--- a/src/Infrastructure/Persistence/MySQLThreadRepository.php
+++ b/src/Infrastructure/Persistence/MySQLThreadRepository.php
@@ -96,4 +96,29 @@ class MySQLThreadRepository implements ThreadRepositoryInterface
         }
     }
     
+    /**
+     * Guarda un hilo en la base de datos.
+     * @param Thread $thread
+     * @return bool
+     */
+    public function save(Thread $thread): bool
+    {
+        try {
+            $query = "INSERT INTO threads (threads_title, threads_desc, threads_cat_id, threads_user_id, threads_reg_date) VALUES (:title, :description, :categoryId, :userId, :timestamp)";
+            $statement = $this->_connection->prepare($query);
+            $title = $thread->getTitle();
+            $description = $thread->getDescription();
+            $categoryId = $thread->getCategoryId();
+            $userId = $thread->getUserId();
+            $timestamp = $thread->getTimestamp();
+            $statement->bindParam(':title', $title, PDO::PARAM_STR);
+            $statement->bindParam(':description', $description, PDO::PARAM_STR);
+            $statement->bindParam(':categoryId', $categoryId, PDO::PARAM_INT);
+            $statement->bindParam(':userId', $userId, PDO::PARAM_INT);
+            $statement->bindParam(':timestamp', $timestamp, PDO::PARAM_STR);
+            return $statement->execute();
+        } catch (PDOException $exception) {
+            throw new RuntimeException("Error al guardar el hilo en la base de datos.", (int) $exception->getCode(), $exception);
+        }
+    }
 }


### PR DESCRIPTION
📝 ¿Qué hace este cambio?

Este PR actualiza la interfaz ThreadRepositoryInterface para incluir el método save(Thread $thread): bool y lo implementa en MySQLThreadRepository usando sentencias preparadas de PDO. Ahora es posible guardar nuevos hilos de forma segura en la base de datos.

Se lograron los siguientes avances:

Interfaz actualizada: ThreadRepositoryInterface ahora exige el método save para persistencia de hilos.
Implementación segura: MySQLThreadRepository implementa save() usando consultas preparadas y bindParam para evitar inyecciones SQL.
Integridad de datos: El método recibe una entidad Thread y almacena sus datos en la tabla threads.

🏗️ Principios y Buenas Prácticas Aplicadas

Seguridad: Uso de sentencias preparadas para evitar inyección SQL.
Clean Code: Separación de responsabilidades y cumplimiento de contratos de interfaz.
🔗 Issue relacionado

Closes #35