### PR TITLE
Feature/controlador vista busqueda

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -46,6 +46,9 @@ $getThreadsByCategoryUseCase = new GetThreadsByCategoryUseCase($threadRepository
 $commentRepository = new MySQLCommentRepository($pdo);
 $getCommentsByThreadUseCase = new GetCommentsByThreadUseCase($commentRepository);
 
+$searchThreadsUseCase = new SearchThreadsUseCase($threadRepository);
+$searchController = new SearchController($searchThreadsUseCase, $viewRenderer);
+
 $viewsPath = __DIR__ . '/../views';
 $viewRenderer = new ViewRenderer($viewsPath);
 
@@ -76,6 +79,13 @@ $authController = new AuthController(
 );
 
 $router = new Router();
-$routerConfigurator = new RouterConfigurator($router, $categoryController, $threadController, $authController);
+$routerConfigurator = new RouterConfigurator(
+    $router, 
+    $categoryController, 
+    $threadController, 
+    $authController, 
+    $searchController
+);
+
 $routerConfigurator->registerRoutes();
 $router->run();

--- a/src/Application/UseCases/SearchThreadsUseCase.php
+++ b/src/Application/UseCases/SearchThreadsUseCase.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lenovo\ProyectoRefactorizacion\Application\UseCases;
+
+use Lenovo\ProyectoRefactorizacion\Domain\Repositories\ThreadRepositoryInterface;
+
+class SearchThreadsUseCase
+{
+    private ThreadRepositoryInterface $_threadRepository;
+
+    public function __construct(ThreadRepositoryInterface $threadRepository)
+    {
+        $this->_threadRepository = $threadRepository;
+    }
+
+    /**
+     * Ejecuta la búsqueda de hilos.
+     *
+     * @param string $keyword
+     * @return array<\Lenovo\ProyectoRefactorizacion\Domain\Entities\Thread>
+     */
+    
+    public function execute(string $keyword): array
+    {
+        // Validación temprana: si la búsqueda está vacía, no consultamos la BD
+        if (trim($keyword) === '') {
+            return [];
+        }
+
+        return $this->_threadRepository->search($keyword);
+    }
+}

--- a/src/Presentation/Controllers/SearchController.php
+++ b/src/Presentation/Controllers/SearchController.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lenovo\ProyectoRefactorizacion\Presentation\Controllers;
+
+use Lenovo\ProyectoRefactorizacion\Application\UseCases\SearchThreadsUseCase;
+use Lenovo\ProyectoRefactorizacion\Presentation\Views\ViewRenderer;
+
+class SearchController
+{
+    private SearchThreadsUseCase $_searchThreadsUseCase;
+    private ViewRenderer $_viewRenderer;
+
+    public function __construct(
+        SearchThreadsUseCase $searchThreadsUseCase,
+        ViewRenderer $viewRenderer
+    ) {
+        $this->_searchThreadsUseCase = $searchThreadsUseCase;
+        $this->_viewRenderer = $viewRenderer;
+    }
+
+    public function index(): void
+    {
+        // Capturamos el parámetro 'search' de la URL 
+        $keyword = $_GET['search'] ?? '';
+        
+        $results = $this->_searchThreadsUseCase->execute((string) $keyword);
+
+        $this->_viewRenderer->render('search/index', [
+            'keyword' => $keyword,
+            'results' => $results
+        ]);
+    }
+}

--- a/src/Presentation/Routing/RouterConfigurator.php
+++ b/src/Presentation/Routing/RouterConfigurator.php
@@ -36,6 +36,8 @@
             $categoryController = $this->_categoryController;
             $threadController = $this->_threadController;
             $authController = $this->_authController;
+            $searchController = $this->_searchController;
+
 
             $this->_router->get('/', function () use ($categoryController) {
                 $categoryController->index();
@@ -78,5 +80,10 @@
             $this->_router->get('/logout', function () use ($authController) {
                 $authController->logout();
             });
+
+            $this->_router->get('/buscar', function () use ($searchController) {
+                $searchController->index();
+            });
+
         }
     }

--- a/views/search/index.php
+++ b/views/search/index.php
@@ -1,0 +1,32 @@
+<?php declare(strict_types=1); ?>
+
+<div class="container my-4">
+    <h1 class="mb-4">Resultados de la búsqueda para: <em>"<?php echo htmlspecialchars($keyword); ?>"</em></h1>
+
+    <div class="list-group">
+        <?php if (!empty($results)): ?>
+            <?php foreach ($results as $thread): ?>
+                <a href="/proyectorefactorizacion/public/hilo/<?php echo $thread->getId(); ?>" class="list-group-item list-group-item-action d-flex gap-3 py-3 shadow-sm mb-2 rounded border">
+                    <img src="https://ui-avatars.com/api/?name=User+<?php echo $thread->getUserId(); ?>&background=random" alt="Avatar" width="40" height="40" class="rounded-circle flex-shrink-0">
+                    <div class="d-flex gap-2 w-100 justify-content-between">
+                        <div>
+                            <h5 class="mb-1 text-success"><?php echo htmlspecialchars($thread->getTitle()); ?></h5>
+                            <p class="mb-0 opacity-75"><?php echo htmlspecialchars(substr($thread->getDescription(), 0, 150)) . '...'; ?></p>
+                        </div>
+                        <small class="opacity-50 text-nowrap"><?php echo htmlspecialchars($thread->getTimestamp()); ?></small>
+                    </div>
+                </a>
+            <?php endforeach; ?>
+        <?php elseif (trim($keyword) === ''): ?>
+            <div class="alert alert-info" role="alert">
+                Por favor, ingresa un término de búsqueda en la barra superior.
+            </div>
+        <?php else: ?>
+            <div class="p-5 bg-light rounded-3 shadow-sm text-center">
+                <h2 class="display-6">No se encontraron resultados</h2>
+                <p class="lead">No hemos encontrado ningún tema que coincida con "<b><?php echo htmlspecialchars($keyword); ?></b>".</p>
+                <p>Asegúrate de que las palabras estén escritas correctamente o intenta con palabras clave diferentes.</p>
+            </div>
+        <?php endif; ?>
+    </div>
+</div>


### PR DESCRIPTION
## 📝 ¿Qué hace este cambio?
Este PR implementa el flujo completo de la funcionalidad de búsqueda, recreando el comportamiento del buscador original del navbar de iDiscuss pero bajo Clean Architecture.

Se lograron los siguientes avances:
1. **Caso de Uso:** Se implementó `SearchThreadsUseCase` para orquestar la llamada al repositorio con una validación temprana para búsquedas vacías.
2. **Controlador:** Se creó `SearchController@index` que procesa la variable global `$_GET['search']` y delega la responsabilidad a la capa de Aplicación.
3. **Presentación:** Se creó la vista `search/index.php` con estados manejados condicionalmente (resultados encontrados, búsqueda vacía, o sin resultados).
4. **Enrutamiento:** Se registró la ruta `/buscar` y se realizó el ensamblaje en `public/index.php`.

## 🏗️ Principios y Buenas Prácticas Aplicadas

- [x] **SRP (Responsabilidad Única):** El controlador se limita a extraer la query string de la URL y mandarla a procesar. La vista solo se encarga de dibujar el resultado final.
- [x] **Clean Code:** Uso de tipado estricto. Implementación masiva de `htmlspecialchars()` en la vista para blindar el buscador contra ataques XSS (Cross-Site Scripting) al reflejar el término de búsqueda ingresado por el usuario.

## 🔗 Issue relacionado
Closes #71